### PR TITLE
add integration with the data viewer

### DIFF
--- a/components/dataset-card.js
+++ b/components/dataset-card.js
@@ -1,6 +1,7 @@
 import { Box, Text } from 'theme-ui'
 
 import {
+  DataViewer,
   License,
   Links,
   Maintainers,
@@ -11,6 +12,7 @@ import {
 export const DatasetCard = ({ dataset }) => {
   const {
     name,
+    stores,
     providers,
     description,
     thumbnail,
@@ -51,6 +53,9 @@ export const DatasetCard = ({ dataset }) => {
             {description}
           </Text>
         </Box>
+
+        {/* display data-viewer link when the dataset has a single store  */}
+        {stores.length === 1 && <DataViewer store={stores[0]} />}
 
         <License license={license} />
 

--- a/components/dataset/data-viewer.js
+++ b/components/dataset/data-viewer.js
@@ -1,0 +1,18 @@
+import { LinkGroup } from '@carbonplan/components'
+import { Box } from 'theme-ui'
+
+const dataViewerInstance = 'https://ncview-js.staging.carbonplan.org'
+export const DataViewer = ({ store }) => {
+  return (
+    <Box sx={{ mt: 3 }}>
+      <LinkGroup
+        members={[
+          {
+            label: `Explore ${store.name}`,
+            href: `${dataViewerInstance}/?dataset=${store.href}`,
+          },
+        ]}
+      />
+    </Box>
+  )
+}

--- a/components/dataset/index.js
+++ b/components/dataset/index.js
@@ -1,3 +1,4 @@
+export { DataViewer } from '@/components/dataset/data-viewer'
 export { License } from '@/components/dataset/license'
 export { Links } from '@/components/dataset/links'
 export { Maintainers } from '@/components/dataset/maintainers'


### PR DESCRIPTION
the purpose of this pull request is to add integration with the data viewer. as it stands, the index page contains a hyperlink labeled `Explore {store.name}` which acts as a direct link to the data viewer. this feature is only visible in cases where datasets have single zarr store. 


Cc @katamartin