### PR TITLE
Catalog tweaks

### DIFF
--- a/components/catalog.js
+++ b/components/catalog.js
@@ -2,6 +2,7 @@ import { DatasetCard } from '@/components/dataset-card'
 import { SearchBox } from '@/components/search-box'
 import { fetcher } from '@/utils/fetcher'
 import { Column, Row } from '@carbonplan/components'
+import { useMemo, useState } from 'react'
 import useSWR from 'swr'
 import { Box, Text } from 'theme-ui'
 
@@ -9,8 +10,26 @@ export const Catalog = ({}) => {
   const { data: datasets, error } = useSWR(
     'https://raw.githubusercontent.com/leap-stc/data-management/main/catalog/datasets/consolidated-web-catalog.json',
     fetcher,
-    { dedupingInterval: 60 * 60 * 1000 }, // 1 hour in milliseconds
+    { dedupingInterval: 60 * 60 * 1000 } // 1 hour in milliseconds
   )
+  const [search, setSearch] = useState('')
+
+  const filteredDatasets = useMemo(() => {
+    if (!datasets) {
+      return []
+    }
+
+    if (!search) {
+      return datasets
+    }
+
+    const re = new RegExp(search, 'i')
+
+    return datasets.filter(
+      (d) => d.name.match(re) || d.tags?.some((tag) => tag.match(re))
+    )
+  }, [datasets, search])
+
   if (error) {
     return <div>Error loading datasets from catalog</div>
   }
@@ -35,13 +54,13 @@ export const Catalog = ({}) => {
           </Text>
         </Column>
         <Column start={[1, 5, 5, 5]} width={[6, 4, 6, 6]} sx={{ mt: 4 }}>
-          <SearchBox />
+          <SearchBox search={search} setSearch={setSearch} />
         </Column>
       </Row>
 
       <Box mt={3}>
         <Row>
-          {datasets?.map(function (dataset, index) {
+          {filteredDatasets.map(function (dataset, index) {
             return (
               <Column
                 key={dataset.name}

--- a/components/catalog.js
+++ b/components/catalog.js
@@ -10,7 +10,7 @@ export const Catalog = ({}) => {
   const { data: datasets, error } = useSWR(
     'https://raw.githubusercontent.com/leap-stc/data-management/main/catalog/datasets/consolidated-web-catalog.json',
     fetcher,
-    { dedupingInterval: 60 * 60 * 1000 } // 1 hour in milliseconds
+    { dedupingInterval: 60 * 60 * 1000 }, // 1 hour in milliseconds
   )
   const [search, setSearch] = useState('')
 
@@ -26,7 +26,7 @@ export const Catalog = ({}) => {
     const re = new RegExp(search, 'i')
 
     return datasets.filter(
-      (d) => d.name.match(re) || d.tags?.some((tag) => tag.match(re))
+      (d) => d.name.match(re) || d.tags?.some((tag) => tag.match(re)),
     )
   }, [datasets, search])
 

--- a/components/dataset/thumbnail.js
+++ b/components/dataset/thumbnail.js
@@ -2,8 +2,9 @@ import { Box, Image, Link } from 'theme-ui'
 import { Badge } from '@carbonplan/components'
 import { alpha } from '@theme-ui/color'
 
-export const Thumbnail = ({ thumbnail, name, demo, stores }) => {
+export const Thumbnail = ({ thumbnail, name, demo }) => {
   const fallbackThumbnail = 'https://via.placeholder.com/400x200'
+
   return (
     <Box mt={3} sx={{ position: 'relative' }}>
       <Link>

--- a/components/dataset/thumbnail.js
+++ b/components/dataset/thumbnail.js
@@ -6,9 +6,7 @@ export const Thumbnail = ({ thumbnail, name, demo, stores }) => {
   const fallbackThumbnail = 'https://via.placeholder.com/400x200'
   return (
     <Box mt={3} sx={{ position: 'relative' }}>
-      <Link
-        href={`https://ncview-js.staging.carbonplan.org/?dataset=${stores[0].href}`}
-      >
+      <Link>
         <Image
           src={thumbnail ?? fallbackThumbnail}
           alt={`Thumbnail for ${name}`}

--- a/components/search-box.js
+++ b/components/search-box.js
@@ -1,7 +1,7 @@
 import { Input } from '@carbonplan/components'
 import { Box, Flex, Text } from 'theme-ui'
 
-export const SearchBox = ({ sx }) => {
+export const SearchBox = ({ sx, search, setSearch }) => {
   return (
     <Box as='section' sx={{ width: '100%', ...sx }}>
       <Flex
@@ -27,6 +27,8 @@ export const SearchBox = ({ sx }) => {
           <form>
             <Input
               size='md'
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
               sx={{
                 flexGrow: 1,
                 width: '100%',


### PR DESCRIPTION
This PR makes some tweaks to the catalog page with the intention of making the catalog ready for use as a really lightweight, internal prototype.
- Remove links to data viewer
  - Data access patterns TBD
- Add crude search functionality
  - Currently performs string-matching checks against dataset `name` and `tags`