### PR TITLE
add tooltip for non-public data accessibility

### DIFF
--- a/components/feedstock/stores.js
+++ b/components/feedstock/stores.js
@@ -1,5 +1,5 @@
 import { Button, Expander } from '@carbonplan/components'
-import { RotatingArrow } from '@carbonplan/icons'
+import { RotatingArrow, Arrow } from '@carbonplan/icons'
 import { Code } from '@carbonplan/prism'
 import AnimateHeight from 'react-animate-height'
 import { Box, Flex, Text } from 'theme-ui'
@@ -124,11 +124,15 @@ const Store = ({ dataset, color }) => {
               }
             }}
             suffix={
-              <RotatingArrow
-                sx={{
-                  transform: ['translateY(-6%)'],
-                }}
-              />
+              dataset.public ? (
+                <RotatingArrow
+                  sx={{
+                    transform: ['translateY(-6%)'],
+                  }}
+                />
+              ) : (
+                <Arrow />
+              )
             }
             sx={{
               color: color,
@@ -140,7 +144,6 @@ const Store = ({ dataset, color }) => {
               mb: 2,
               cursor: dataset.public ? 'pointer' : 'not-allowed', // Changes cursor to indicate disabled state
               color: dataset.public ? color : 'secondary', // Grey out the button when disabled
-              pointerEvents: dataset.public ? 'auto' : 'none', // Disables pointer events when dataset is not public
             }}
           >
             Open in Data Viewer

--- a/components/feedstock/stores.js
+++ b/components/feedstock/stores.js
@@ -139,7 +139,7 @@ const Store = ({ dataset, color }) => {
               mt: 3,
               mb: 2,
               cursor: dataset.public ? 'pointer' : 'not-allowed', // Changes cursor to indicate disabled state
-              opacity: dataset.public ? 1 : 0.5, // Grey out the button when disabled
+              color: dataset.public ? color : 'secondary', // Grey out the button when disabled
               pointerEvents: dataset.public ? 'auto' : 'none', // Disables pointer events when dataset is not public
             }}
           >

--- a/components/feedstock/stores.js
+++ b/components/feedstock/stores.js
@@ -3,6 +3,7 @@ import { RotatingArrow } from '@carbonplan/icons'
 import { Code } from '@carbonplan/prism'
 import AnimateHeight from 'react-animate-height'
 import { Box, Flex, Text } from 'theme-ui'
+import { TooltipWrapper } from '@/components/tooltip'
 
 import { Check, Down } from '@carbonplan/icons'
 import { useState } from 'react'
@@ -23,6 +24,7 @@ const Store = ({ dataset, color }) => {
 
   const [copied, setCopied] = useState(false)
   const [tick, setTick] = useState(null)
+  const [tooltipExpanded, setTooltipExpanded] = useState(false)
 
   const handleClick = (url) => {
     const blank = document.createElement('textarea')
@@ -41,21 +43,32 @@ const Store = ({ dataset, color }) => {
     setTick(timeout)
   }
 
+  const tooltipContent = dataset.public
+    ? ''
+    : 'This dataset is private. Access requires credentials or a Columbia-LEAP JupyterHub server.'
+
   return (
     <Flex
       sx={{ flexDirection: 'column', '& pre': { fontSize: '10px', my: 2 } }}
     >
-      <Button
-        sx={{
-          color: color,
-          fontSize: [2, 2, 2, 3],
-          textTransform: 'uppercase',
-        }}
-        onClick={() => setExpanded((prev) => !prev)}
+      <TooltipWrapper
+        tooltip={tooltipContent}
+        color={color}
+        expanded={!dataset.public && tooltipExpanded}
+        setExpanded={setTooltipExpanded}
       >
-        <Text sx={{ mr: [2] }}>{name || id}</Text>
-        <Expander value={expanded} />
-      </Button>
+        <Button
+          sx={{
+            color: color,
+            fontSize: [2, 2, 2, 3],
+            textTransform: 'uppercase',
+          }}
+          onClick={() => setExpanded((prev) => !prev)}
+        >
+          <Text sx={{ mr: [2] }}>{name || id}</Text>
+          <Expander value={expanded} />
+        </Button>
+      </TooltipWrapper>
 
       <AnimateHeight
         duration={100}
@@ -126,7 +139,8 @@ const Store = ({ dataset, color }) => {
               mt: 3,
               mb: 2,
               cursor: dataset.public ? 'pointer' : 'not-allowed', // Changes cursor to indicate disabled state
-              //opacity: dataset.public ? 1 : 0.5, // Reduces opacity to indicate disabled state
+              opacity: dataset.public ? 1 : 0.5, // Grey out the button when disabled
+              pointerEvents: dataset.public ? 'auto' : 'none', // Disables pointer events when dataset is not public
             }}
           >
             Open in Data Viewer

--- a/components/tooltip.js
+++ b/components/tooltip.js
@@ -1,0 +1,76 @@
+import { IconButton } from 'theme-ui'
+import { Info } from '@carbonplan/icons'
+
+import { Box, Flex } from 'theme-ui'
+import { useState } from 'react'
+import AnimateHeight from 'react-animate-height'
+
+const Tooltip = ({ expanded, setExpanded, sx }) => {
+  return (
+    <IconButton
+      onClick={() => setExpanded(!expanded)}
+      role='checkbox'
+      aria-checked={expanded}
+      aria-label='Information'
+      sx={{
+        cursor: 'pointer',
+        height: '16px',
+        width: '16px',
+        '@media (hover: hover) and (pointer: fine)': {
+          '&:hover > #info': {
+            stroke: 'primary',
+          },
+        },
+        p: [0],
+        transform: 'translate(0px, -3.75px)',
+        ...sx,
+      }}
+    >
+      <Info
+        id='info'
+        sx={{
+          stroke: expanded ? 'primary' : 'secondary',
+          transition: '0.1s',
+        }}
+      />
+    </IconButton>
+  )
+}
+
+export const TooltipWrapper = ({
+  children,
+  tooltip,
+  mt = '8px',
+  color,
+  sx,
+}) => {
+  const [expanded, setExpanded] = useState(false)
+
+  return tooltip ? (
+    <>
+      <Flex
+        sx={{
+          justifyContent: 'space-between',
+          alignItems: 'flex-start',
+          ...sx,
+        }}
+      >
+        {children}
+        <Tooltip
+          expanded={expanded}
+          setExpanded={setExpanded}
+          sx={{ mt: mt, flexShrink: 0 }}
+        />
+      </Flex>
+      <AnimateHeight
+        duration={100}
+        height={expanded ? 'auto' : 0}
+        easing={'linear'}
+      >
+        <Box sx={{ my: 1, fontSize: [2, 2, 2, 3], color }}>{tooltip}</Box>
+      </AnimateHeight>
+    </>
+  ) : (
+    <>{children}</>
+  )
+}

--- a/components/tooltip.js
+++ b/components/tooltip.js
@@ -67,7 +67,7 @@ export const TooltipWrapper = ({
         height={expanded ? 'auto' : 0}
         easing={'linear'}
       >
-        <Box sx={{ my: 1, fontSize: [2, 2, 2, 3], color }}>{tooltip}</Box>
+        <Box sx={{ mt: 2, fontSize: [1, 1, 1, 2], color }}>{tooltip}</Box>
       </AnimateHeight>
     </>
   ) : (

--- a/components/tooltip.js
+++ b/components/tooltip.js
@@ -50,17 +50,18 @@ export const TooltipWrapper = ({
     <>
       <Flex
         sx={{
-          justifyContent: 'space-between',
-          alignItems: 'flex-start',
+          justifyContent: 'flex-start',
+          alignItems: 'center',
+          gap: 2,
           ...sx,
         }}
       >
-        {children}
         <Tooltip
           expanded={expanded}
           setExpanded={setExpanded}
           sx={{ mt: mt, flexShrink: 0 }}
         />
+        {children}
       </Flex>
       <AnimateHeight
         duration={100}


### PR DESCRIPTION
This PR is another stab at  giving better visual feedback and preventing interactions on private datasets. the Tooltip component is a replica of the component in offsets-db-web :) 

- closes #38

