### PR TITLE
fix direct URL navigation

### DIFF
--- a/components/feedstock-card.js
+++ b/components/feedstock-card.js
@@ -4,6 +4,7 @@ import {
 } from '@/utils/string-hash'
 import { Link } from '@carbonplan/components'
 import { Box, Flex } from 'theme-ui'
+import { useEffect } from 'react'
 
 import {
   License,
@@ -66,6 +67,13 @@ export const FeedstockCard = ({ feedstock }) => {
 
   const color = colors[colorIndex]
   const id = title.toLowerCase().replace(/\s+/g, '-') // Convert title to id
+
+  useEffect(() => {
+    // Check if the current URL hash matches the id of this card
+    if (window.location.hash === `#${id}`) {
+      document.getElementById(id)?.scrollIntoView({ behavior: 'smooth' })
+    }
+  }, [id])
 
   return (
     <>


### PR DESCRIPTION
This PR addresses an issue where navigating directly to a URL with a hash (e.g., https://catalog.leap.columbia.edu/#noaa-coastwatch-geo-polar-sst) did not correctly scroll to the corresponding `FeedstockCard`. The changes ensure that the page smoothly scrolls to the targeted `FeedstockCard` when navigating directly to a URL with a hash.

- #65 follow-up