### PR TITLE
Refactor event tracking and navigation in _app.js

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -9,23 +9,22 @@ export default function App({ Component, pageProps }) {
   const router = useRouter()
   useEffect(() => {
     const handleRouteChange = (url) => {
-      if (url.includes('#')) {
-        const [pathname, hash] = url.split('#')
-        gtag.event({
-          action: 'navigate_to_section',
-          category: 'Navigation',
-          label: hash,
-          value: pathname,
-        })
-      } else {
-        gtag.pageview(url)
-      }
+      gtag.pageview(url)
+    }
+    const handleHashChange = (url) => {
+      const [pathname, hash] = url.split('#')
+      gtag.event({
+        action: 'navigate_to_section',
+        category: 'Navigation',
+        label: hash,
+        value: pathname,
+      })
     }
     router.events.on('routeChangeComplete', handleRouteChange)
-    router.events.on('hashChangeComplete', handleRouteChange)
+    router.events.on('hashChangeComplete', handleHashChange)
     return () => {
       router.events.off('routeChangeComplete', handleRouteChange)
-      router.events.off('hashChangeComplete', handleRouteChange)
+      router.events.off('hashChangeComplete', handleHashChange)
     }
   }, [router.events])
   return (


### PR DESCRIPTION
this PR separates the handlers for route changes and hash changes:

- `handleRouteChange` now only calls `gtag.pageview(url)` for full page changes.
- `handleHashChange` is a new function that handles hash changes and sends them as events.

this is another attempt at addressing:
- https://github.com/leap-stc/data-and-compute-team/issues/16#issuecomment-2302184868
